### PR TITLE
fix(webgl): safe renderer init, error boundaries, and resilient rAF l…

### DIFF
--- a/components/DataFlowVisual.tsx
+++ b/components/DataFlowVisual.tsx
@@ -10,8 +10,12 @@ import {
   Points,
   PointsMaterial,
   Scene,
-  WebGLRenderer,
 } from "three";
+
+import {
+  createWebGLRendererSafely,
+  isRendererContextUsable,
+} from "@/lib/webgl";
 
 const IS_MOBILE = typeof window !== "undefined" && window.innerWidth < 768;
 const PARTICLE_COUNT = IS_MOBILE ? 800 : 1800;
@@ -32,12 +36,14 @@ export default function DataFlowVisual({ className }: DataFlowVisualProps) {
     const camera = new PerspectiveCamera(75, 1, 0.1, 1000);
     camera.position.z = 50;
 
-    const renderer = new WebGLRenderer({
+    const renderer = createWebGLRendererSafely({
       antialias: ANTIALIAS,
       alpha: true,
       powerPreference: "low-power",
       precision: "mediump",
     });
+    if (!renderer) return;
+
     renderer.setSize(1, 1);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     const canvas = renderer.domElement;
@@ -77,12 +83,12 @@ export default function DataFlowVisual({ className }: DataFlowVisualProps) {
 
     scene.add(new Points(geometry, material));
 
-    let animId: number;
+    let animId: number | undefined;
     const clock = new Clock();
 
     const animate = () => {
-      if (!alive) return;
-      animId = requestAnimationFrame(animate);
+      if (!alive || !isRendererContextUsable(renderer)) return;
+
       const time = clock.getElapsedTime();
       const posArr = geometry.attributes.position.array as Float32Array;
       const colArr = geometry.attributes.color.array as Float32Array;
@@ -114,7 +120,14 @@ export default function DataFlowVisual({ className }: DataFlowVisualProps) {
       }
       geometry.attributes.position.needsUpdate = true;
       geometry.attributes.color.needsUpdate = true;
-      renderer.render(scene, camera);
+
+      try {
+        renderer.render(scene, camera);
+      } catch {
+        return;
+      }
+
+      animId = requestAnimationFrame(animate);
     };
     animate();
 
@@ -154,7 +167,7 @@ export default function DataFlowVisual({ className }: DataFlowVisualProps) {
       alive = false;
       window.clearTimeout(resizeDebounceT);
       ro.disconnect();
-      cancelAnimationFrame(animId);
+      if (animId !== undefined) cancelAnimationFrame(animId);
       renderer.dispose();
       geometry.dispose();
       material.dispose();

--- a/components/HeroBackdrop.tsx
+++ b/components/HeroBackdrop.tsx
@@ -5,6 +5,7 @@ import {
   DynamicHeroVisual,
   HeroCanvasPlaceholder,
 } from "@/components/landing/HeavyVisuals";
+import { WebGLErrorBoundary } from "@/components/WebGLErrorBoundary";
 
 /** Hero WebGL + gradient layers only (LCP text lives in RSC `page.tsx`). */
 export function HeroBackdrop() {
@@ -14,7 +15,9 @@ export function HeroBackdrop() {
         fallback={<HeroCanvasPlaceholder />}
         delayMs={650}
       >
-        <DynamicHeroVisual />
+        <WebGLErrorBoundary fallback={<HeroCanvasPlaceholder />}>
+          <DynamicHeroVisual />
+        </WebGLErrorBoundary>
       </DeferHeavyChild>
       <div
         className="pointer-events-none absolute inset-0 z-[1] bg-transparent opacity-100"

--- a/components/HeroVisual.tsx
+++ b/components/HeroVisual.tsx
@@ -11,8 +11,12 @@ import {
   PointsMaterial,
   Scene,
   Vector2,
-  WebGLRenderer,
 } from "three";
+
+import {
+  createWebGLRendererSafely,
+  isRendererContextUsable,
+} from "@/lib/webgl";
 
 const IS_MOBILE = typeof window !== "undefined" && window.innerWidth < 768;
 /** 4 000 on mobile (up from 2 400): still a single Points draw call, single BufferGeometry. */
@@ -50,12 +54,14 @@ export default function HeroVisual() {
       else { camera.position.z = 450; camera.fov = 75; }
     };
 
-    const renderer = new WebGLRenderer({
+    const renderer = createWebGLRendererSafely({
       antialias: ANTIALIAS,
       alpha: true,
       powerPreference: "low-power",
       precision: "mediump",
     });
+    if (!renderer) return;
+
     renderer.setSize(1, 1);
     /** Use real dPR but cap at 2 — sharp on Retina/AMOLED without killing fill rate. */
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
@@ -182,12 +188,12 @@ export default function HeroVisual() {
     });
     resizeObserver.observe(container, { box: "border-box" });
 
-    let animationFrameId: number;
+    let animationFrameId: number | undefined;
     const clock = new Clock();
 
     const animate = () => {
-      if (!alive) return;
-      animationFrameId = requestAnimationFrame(animate);
+      if (!alive || !isRendererContextUsable(renderer)) return;
+
       const elapsed = clock.getElapsedTime();
 
       pointCloud.rotation.y += (targetRotationY - pointCloud.rotation.y) * 0.04;
@@ -233,7 +239,14 @@ export default function HeroVisual() {
 
       posAttr.needsUpdate = true;
       linesGeom.attributes.position.needsUpdate = true;
-      renderer.render(scene, camera);
+
+      try {
+        renderer.render(scene, camera);
+      } catch {
+        return;
+      }
+
+      animationFrameId = requestAnimationFrame(animate);
     };
 
     animate();
@@ -244,7 +257,9 @@ export default function HeroVisual() {
       window.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("click", onClick);
       resizeObserver.disconnect();
-      cancelAnimationFrame(animationFrameId);
+      if (animationFrameId !== undefined) {
+        cancelAnimationFrame(animationFrameId);
+      }
       renderer.dispose();
       particlesGeom.dispose();
       particlesMat.dispose();

--- a/components/InfrastructureGrid.tsx
+++ b/components/InfrastructureGrid.tsx
@@ -13,8 +13,12 @@ import {
   Scene,
   Vector2,
   Vector3,
-  WebGLRenderer,
 } from "three";
+
+import {
+  createWebGLRendererSafely,
+  isRendererContextUsable,
+} from "@/lib/webgl";
 
 const IS_MOBILE = typeof window !== "undefined" && window.innerWidth < 768;
 const SEGMENTS = IS_MOBILE ? 30 : 60;
@@ -36,7 +40,14 @@ export default function InfrastructureGrid({ className }: Props) {
     camera.position.set(0, -25, 12);
     camera.lookAt(0, 0, 0);
 
-    const renderer = new WebGLRenderer({ antialias: ANTIALIAS, alpha: true, powerPreference: "low-power", precision: "mediump" });
+    const renderer = createWebGLRendererSafely({
+      antialias: ANTIALIAS,
+      alpha: true,
+      powerPreference: "low-power",
+      precision: "mediump",
+    });
+    if (!renderer) return;
+
     renderer.setSize(1, 1);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     const canvas = renderer.domElement;
@@ -70,11 +81,11 @@ export default function InfrastructureGrid({ className }: Props) {
     container.addEventListener("mouseleave", onLeave);
 
     const clock = new Clock();
-    let animId: number;
+    let animId: number | undefined;
 
     const animate = () => {
-      if (!alive) return;
-      animId = requestAnimationFrame(animate);
+      if (!alive || !isRendererContextUsable(renderer)) return;
+
       const time = clock.getElapsedTime();
       const posAttr = geometry.attributes.position;
 
@@ -92,7 +103,14 @@ export default function InfrastructureGrid({ className }: Props) {
         posAttr.setZ(i, vz);
       }
       posAttr.needsUpdate = true;
-      renderer.render(scene, camera);
+
+      try {
+        renderer.render(scene, camera);
+      } catch {
+        return;
+      }
+
+      animId = requestAnimationFrame(animate);
     };
     animate();
 
@@ -135,7 +153,7 @@ export default function InfrastructureGrid({ className }: Props) {
       container.removeEventListener("mousemove", onMouseMove);
       container.removeEventListener("mouseenter", onEnter);
       container.removeEventListener("mouseleave", onLeave);
-      cancelAnimationFrame(animId);
+      if (animId !== undefined) cancelAnimationFrame(animId);
       renderer.dispose();
       geometry.dispose();
       material.dispose();

--- a/components/MarketPulseVisual.tsx
+++ b/components/MarketPulseVisual.tsx
@@ -9,8 +9,12 @@ import {
   LineBasicMaterial,
   PerspectiveCamera,
   Scene,
-  WebGLRenderer,
 } from "three";
+
+import {
+  createWebGLRendererSafely,
+  isRendererContextUsable,
+} from "@/lib/webgl";
 
 const IS_MOBILE = typeof window !== "undefined" && window.innerWidth < 768;
 const SEGMENT_COUNT = IS_MOBILE ? 100 : 200;
@@ -31,7 +35,14 @@ export default function MarketPulseVisual({ className }: Props) {
     const camera = new PerspectiveCamera(50, 1, 0.1, 1000);
     camera.position.z = 50;
 
-    const renderer = new WebGLRenderer({ antialias: ANTIALIAS, alpha: true, powerPreference: "low-power", precision: "mediump" });
+    const renderer = createWebGLRendererSafely({
+      antialias: ANTIALIAS,
+      alpha: true,
+      powerPreference: "low-power",
+      precision: "mediump",
+    });
+    if (!renderer) return;
+
     renderer.setSize(1, 1);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     const canvas = renderer.domElement;
@@ -58,12 +69,12 @@ export default function MarketPulseVisual({ className }: Props) {
       geometries.push(geo);
     }
 
-    let animId: number;
+    let animId: number | undefined;
     const clock = new Clock();
 
     const animate = () => {
-      if (!alive) return;
-      animId = requestAnimationFrame(animate);
+      if (!alive || !isRendererContextUsable(renderer)) return;
+
       const elapsed = clock.getElapsedTime();
 
       waves.forEach((line, idx) => {
@@ -78,7 +89,14 @@ export default function MarketPulseVisual({ className }: Props) {
         }
         line.geometry.attributes.position.needsUpdate = true;
       });
-      renderer.render(scene, camera);
+
+      try {
+        renderer.render(scene, camera);
+      } catch {
+        return;
+      }
+
+      animId = requestAnimationFrame(animate);
     };
     animate();
 
@@ -118,7 +136,7 @@ export default function MarketPulseVisual({ className }: Props) {
       alive = false;
       window.clearTimeout(resizeDebounceT);
       ro.disconnect();
-      cancelAnimationFrame(animId);
+      if (animId !== undefined) cancelAnimationFrame(animId);
       geometries.forEach((g) => g.dispose());
       waves.forEach((w) => {
         if (Array.isArray(w.material)) w.material.forEach((m) => m.dispose());

--- a/components/WebGLErrorBoundary.tsx
+++ b/components/WebGLErrorBoundary.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type Props = { children: ReactNode; fallback: ReactNode };
+type State = { hasError: boolean };
+
+/**
+ * Catches render-phase errors from Three.js children. useEffect failures are
+ * handled via `createWebGLRendererSafely` in each visual.
+ */
+export class WebGLErrorBoundary extends Component<Props, State> {
+  override state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: unknown, info: ErrorInfo) {
+    if (process.env.NODE_ENV === "development") {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn("[WebGLErrorBoundary]", msg, info.componentStack);
+    }
+  }
+
+  override render() {
+    if (this.state.hasError) return this.props.fallback;
+    return this.props.children;
+  }
+}

--- a/components/landing/HeavyVisuals.tsx
+++ b/components/landing/HeavyVisuals.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import type { ReactNode } from "react";
+
+import { WebGLErrorBoundary } from "@/components/WebGLErrorBoundary";
 
 /** Static hero background until WebGL mounts (TBT / FCP friendly). */
 export function HeroCanvasPlaceholder() {
@@ -51,8 +54,60 @@ export const DynamicMarketPulseVisual = dynamic(
   { ssr: false, loading: () => <CardVisualPlaceholder /> },
 );
 
+function SafeCardWebGL({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <WebGLErrorBoundary
+      fallback={<CardVisualPlaceholder className={className} />}
+    >
+      {children}
+    </WebGLErrorBoundary>
+  );
+}
+
+export function SafeDynamicDataFlowVisual({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <SafeCardWebGL className={className}>
+      <DynamicDataFlowVisual className={className} />
+    </SafeCardWebGL>
+  );
+}
+
+export function SafeDynamicInfrastructureGrid({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <SafeCardWebGL className={className}>
+      <DynamicInfrastructureGrid className={className} />
+    </SafeCardWebGL>
+  );
+}
+
+export function SafeDynamicMarketPulseVisual({
+  className,
+}: {
+  className?: string;
+}) {
+  return (
+    <SafeCardWebGL className={className}>
+      <DynamicMarketPulseVisual className={className} />
+    </SafeCardWebGL>
+  );
+}
+
 export const projectHeaderVisuals = [
-  DynamicDataFlowVisual,
-  DynamicInfrastructureGrid,
-  DynamicMarketPulseVisual,
+  SafeDynamicDataFlowVisual,
+  SafeDynamicInfrastructureGrid,
+  SafeDynamicMarketPulseVisual,
 ] as const;

--- a/lib/webgl.ts
+++ b/lib/webgl.ts
@@ -1,0 +1,58 @@
+import type { WebGLRendererParameters } from "three";
+import { WebGLRenderer } from "three";
+
+/**
+ * Probes WebGL1 availability (matches typical Three.js WebGLRenderer).
+ * Uses a throwaway canvas and releases the context via WEBGL_lose_context.
+ */
+export function isWebGLAvailable(): boolean {
+  if (typeof document === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    const gl =
+      canvas.getContext("webgl", {
+        alpha: true,
+        antialias: false,
+        depth: true,
+        stencil: false,
+        failIfMajorPerformanceCaveat: false,
+        powerPreference: "low-power",
+      }) ??
+      (canvas.getContext(
+        "experimental-webgl",
+      ) as WebGLRenderingContext | null);
+    if (!gl) return false;
+    const lose = gl.getExtension("WEBGL_lose_context");
+    lose?.loseContext();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Creates a WebGLRenderer only when a context can be obtained; disposes on failure.
+ * Does not call `isWebGLAvailable()` first — that would create a throwaway GL context
+ * on every mount (double allocation, some GPUs cap concurrent contexts).
+ */
+export function createWebGLRendererSafely(
+  params: WebGLRendererParameters,
+): WebGLRenderer | null {
+  try {
+    const renderer = new WebGLRenderer(params);
+    const gl = renderer.getContext();
+    if (!gl || gl.isContextLost()) {
+      renderer.dispose();
+      return null;
+    }
+    return renderer;
+  } catch {
+    return null;
+  }
+}
+
+/** Use inside rAF loops before `render` to stop after context loss or GPU reset. */
+export function isRendererContextUsable(renderer: WebGLRenderer): boolean {
+  const gl = renderer.getContext();
+  return Boolean(gl && !gl.isContextLost());
+}


### PR DESCRIPTION
Add lib/webgl (createWebGLRendererSafely, isWebGLAvailable, isRendererContextUsable) without double context allocation before WebGLRenderer. Wrap hero and project card dynamics in WebGLErrorBoundary with existing placeholders; safe wrappers in HeavyVisuals. Guard all four visuals: skip render when context lost, try/catch around render, schedule rAF only after success, conditional cancelAnimationFrame. Harden componentDidCatch for non-Error throws. Closes #1.