### PR TITLE
feat(security): optional SRI for deferred script; document HSTS preload / Resolved

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ RESEND_TO_EMAIL=
 # next/script with strategy=lazyOnload — extend Content-Security-Policy script-src
 # in next.config.mjs if the host is not already allowed.
 NEXT_PUBLIC_DEFERRED_SCRIPT_SRC=
+
+# Optional Subresource Integrity for the URL above (e.g. sha384-… from your CDN).
+# Required crossOrigin="anonymous" is set automatically when this is present.
+NEXT_PUBLIC_DEFERRED_SCRIPT_INTEGRITY=

--- a/AI_WORK_LOG.md
+++ b/AI_WORK_LOG.md
@@ -29,6 +29,11 @@ Chronological log of **substantive** changes driven by AI-assisted sessions on t
 
 ## Log (newest first)
 
+### 2026-04-03 — Security: optional SRI for deferred third-party script; HSTS note
+
+- **What:** `components/DeferredThirdPartyScripts.tsx` — when `NEXT_PUBLIC_DEFERRED_SCRIPT_INTEGRITY` is set (with `NEXT_PUBLIC_DEFERRED_SCRIPT_SRC`), pass `integrity` and `crossOrigin="anonymous"` to `next/script`. `.env.example` — document the new variable. `next.config.mjs` — comment that current HSTS is preload-eligible and points to hstspreload.org.
+- **Why:** Scanners suggest SRI for external scripts; Next.js app bundles are same-origin and impractical for SRI. Optional env keeps analytics URLs verifiable when the provider documents a hash.
+
 ### 2026-04-03 — SEO: shorten site / OG titles to 50 chars (social preview)
 
 - **What:** `lib/seo.ts` — home `title` for `en` and `de` set to `Kresic Digital Systems — B2B & FinTech Engineering` (50 characters). `app/layout.tsx` — `siteTitle` and default `openGraph.title` aligned with the same string.

--- a/components/DeferredThirdPartyScripts.tsx
+++ b/components/DeferredThirdPartyScripts.tsx
@@ -9,7 +9,16 @@ export function DeferredThirdPartyScripts() {
   const src = process.env.NEXT_PUBLIC_DEFERRED_SCRIPT_SRC?.trim();
   if (!src) return null;
 
+  const integrity = process.env.NEXT_PUBLIC_DEFERRED_SCRIPT_INTEGRITY?.trim();
+
   return (
-    <Script id="deferred-third-party" src={src} strategy="lazyOnload" />
+    <Script
+      id="deferred-third-party"
+      src={src}
+      strategy="lazyOnload"
+      {...(integrity
+        ? { integrity, crossOrigin: "anonymous" as const }
+        : {})}
+    />
   );
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,7 @@ const securityHeaders = [
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=(), payment=()",
   },
+  // Two years; preload-eligible (≥1y + includeSubDomains + preload). Submit apex at https://hstspreload.org/
   {
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",


### PR DESCRIPTION
## Resolved

**Implemented in code**

- **`next.config.mjs`:** HSTS remains preload-eligible (`max-age=63072000; includeSubDomains; preload`); added a short comment pointing to [hstspreload.org](https://hstspreload.org/).
- **`DeferredThirdPartyScripts`:** optional `NEXT_PUBLIC_DEFERRED_SCRIPT_INTEGRITY` — when set together with `NEXT_PUBLIC_DEFERRED_SCRIPT_SRC`, the script gets `integrity` and `crossOrigin="anonymous"`.
- **`.env.example`:** documented the new env var for SRI.
- **`AI_WORK_LOG.md`:** logged the security change.

**Operational (outside the repo)**

- Submitting the domain to the HSTS preload list at [hstspreload.org](https://hstspreload.org/) is still a manual step when you choose to do it (the response header already meets the technical requirements).

**Verify**

- Over HTTPS, confirm `Strict-Transport-Security` matches expectations.
- If you enable a third-party script, set the integrity hash in Vercel and confirm the script loads without CSP/SRI errors.

Closing as completed.  closes #17 